### PR TITLE
Refactor styles.css to remove scrollbar styling for bot message

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -945,33 +945,12 @@
 /* Bot message styling */
 .gemini-message-bot {
 	width: 100%;
-	max-height: 400px;
-	overflow-y: auto;
 	background: var(--chat-bot-bg);
 	border: 1px solid var(--chat-border);
 	border-radius: 12px;
 	margin: 8px 0;
 	padding: 16px;
 	position: relative;
-}
-
-/* Scrollbar styling for the bot message */
-.gemini-message-bot::-webkit-scrollbar {
-	width: 8px;
-}
-
-.gemini-message-bot::-webkit-scrollbar-track {
-	background: var(--chat-bot-bg);
-	border-radius: 0 12px 12px 0;
-}
-
-.gemini-message-bot::-webkit-scrollbar-thumb {
-	background: var(--chat-border);
-	border-radius: 4px;
-}
-
-.gemini-message-bot::-webkit-scrollbar-thumb:hover {
-	background: var(--interactive-accent);
 }
 
 /* Copy button */


### PR DESCRIPTION
This pull request includes changes to the `styles.css` file, focusing on the styling of bot messages. The primary change involves removing the custom scrollbar styling for the bot messages.

Changes to bot message styling:

* Removed the `max-height` and `overflow-y: auto` properties from the `.gemini-message-bot` class to potentially allow for more flexible height management.
* Eliminated the custom scrollbar styling for the `.gemini-message-bot` class, including the `::-webkit-scrollbar`, `::-webkit-scrollbar-track`, `::-webkit-scrollbar-thumb`, and `::-webkit-scrollbar-thumb:hover` pseudo-elements.